### PR TITLE
chore: use forgerock monitoring log group

### DIFF
--- a/terraform/groups/mongodb-connector/main.tf
+++ b/terraform/groups/mongodb-connector/main.tf
@@ -46,8 +46,8 @@ module "ecs-task-primary" {
   fidc_url                   = var.fidc_url
   rcs_server_key             = var.rcs_server_key
   connector_name             = var.connector_name_primary
-  log_group_name             = var.service_name
-  log_prefix                 = "primary"
+  log_group_name             = "forgerock-monitoring"
+  log_prefix                 = "mongodb-connector-primary"
 }
 
 module "ecs-task-secondary" {
@@ -67,7 +67,7 @@ module "ecs-task-secondary" {
   fidc_url                   = var.fidc_url
   rcs_server_key             = var.rcs_server_key
   connector_name             = var.connector_name_secondary
-  log_group_name             = var.service_name
-  log_prefix                 = "secondary"
+  log_group_name             = "forgerock-monitoring"
+  log_prefix                 = "mongodb-connector-secondary"
 }
 

--- a/terraform/groups/mongodb-connector/modules/monitoring/main.tf
+++ b/terraform/groups/mongodb-connector/modules/monitoring/main.tf
@@ -1,3 +1,0 @@
-resource "aws_cloudwatch_log_group" "connector" {
-  name = var.service_name
-}

--- a/terraform/groups/mongodb-connector/modules/monitoring/variables.tf
+++ b/terraform/groups/mongodb-connector/modules/monitoring/variables.tf
@@ -1,3 +1,0 @@
-variable "service_name" {
-  type = string
-}


### PR DESCRIPTION
Update MongoDB connector to use FIDC monitoring CloudWatch group